### PR TITLE
修复 Android4.4.2 下原生按键返回事件绑定问题

### DIFF
--- a/js/mui.back.5+.js
+++ b/js/mui.back.5+.js
@@ -80,27 +80,18 @@
 			}
 		}
 	};
-	//默认监听
-	$.plusReady(function() {
-		if ($.options.keyEventBind.backbutton) {
-			plus.key.addEventListener('backbutton', $.back, false);
-		}
-		if ($.options.keyEventBind.menubutton) {
-			plus.key.addEventListener('menubutton', $.menu, false);
-		}
-	});
+
 	//处理按键监听事件
 	$.registerInit({
 		name: 'keyEventBind',
 		index: 1000,
 		handle: function() {
 			$.plusReady(function() {
-				//如果不为true，则移除默认监听
-				if (!$.options.keyEventBind.backbutton) {
-					plus.key.removeEventListener('backbutton', $.back);
+				if ($.options.keyEventBind.backbutton) {
+					plus.key.addEventListener('backbutton', $.back);
 				}
-				if (!$.options.keyEventBind.menubutton) {
-					plus.key.removeEventListener('menubutton', $.menu);
+				if ($.options.keyEventBind.menubutton) {
+					plus.key.addEventListener('menubutton', $.menu);
 				}
 			});
 		}


### PR DESCRIPTION
因本人在编写代码时，发现1.5版本中的 按键返回事件是有效的，但在最新版本中 1.7 版本，却无效，无奈查看源码发现，在1.5的版本中 注册顺序是默认不注册，然后在根据用户设置的选项来注册，而最新版本中采用的注册顺序是 先将 Back 事件注册，这大概根默认选项有关，因为已经为True了，所以先注册，在最后根据用户的设置选项来移除此 Back 事件，但是就因为这样，在 Andirod 4.4.2 下，按键返回事件却是无效的，反而改用 1.5版本中的 注册机制确是有效的。所以将其改为1.5版本的注册机制，因本人也是新人，不知是否是我配置不当而导致的，希望能查明并告知原因，谢谢！

具体可查看 #76 问题！