### PR TITLE
修复mui.fire方法无法传递数组的问题

### DIFF
--- a/js/mui.init.5+.js
+++ b/js/mui.init.5+.js
@@ -134,7 +134,7 @@
 			} else if(typeof data === 'boolean' || typeof data === 'number') {
 				webview.evalJS("typeof mui!=='undefined'&&mui.receive('" + eventType + "'," + data + ")");
 				return;
-			} else if($.isPlainObject(data)) {
+			} else if($.isPlainObject(data) || $.isArray(data)) {
 				data = JSON.stringify(data || {}).replace(/\'/g, "\\u0027").replace(/\\/g, "\\u005c");
 			}
 			webview.evalJS("typeof mui!=='undefined'&&mui.receive('" + eventType + "','" + data + "')");


### PR DESCRIPTION
fire方法中未对数组进行判断，当data为Array时，isPlainObject方法返回false，导致数组未经过JSON.stringify编码直接传递给webview，目标webview收到的是数组toString后的字符串（如：“[object Object],[object Object]”），不是数组。