### PR TITLE
切换横竖屏时，页面选择出错问题

### DIFF
--- a/js/mui.class.scroll.js
+++ b/js/mui.class.scroll.js
@@ -736,7 +736,7 @@
 			this._reInit();
 			this.reLayout();
 			$.trigger(this.scroller, 'refresh', this);
-			this.resetPosition();
+			this.resetPosition(0,true);
 		},
 		scrollTo: function(x, y, time, easing) {
 			var easing = easing || ease.circular;

--- a/js/mui.class.scroll.slider.js
+++ b/js/mui.class.scroll.slider.js
@@ -316,14 +316,16 @@
 				this.progressBarStyle.webkitTransform = this._getTranslateStr((-x * (this.progressBarWidth / this.wrapperWidth)), 0);
 			}
 		},
-		resetPosition: function(time) {
+		resetPosition: function(time, byCurrentSelect) {
 			time = time || 0;
 			if (this.x > 0) {
 				this.x = 0;
 			} else if (this.x < this.maxScrollX) {
 				this.x = this.maxScrollX;
 			}
-			this.currentPage = this._nearestSnap(this.x);
+			if(!byCurrentSelect){
+				this.currentPage = this._nearestSnap(this.x);
+			}
 			this.scrollTo(this.currentPage.x, 0, time, this.options.scrollEasing);
 			return true;
 		},


### PR DESCRIPTION
在滑动切换下拉刷新页那个demo里面，当为refresh时，不应该再通过近似值重新计算currentPage