### PR TITLE
优化幻灯片组件，不在可视区域时不自动轮播；优化scroll滚动

### DIFF
--- a/js/mui.class.scroll.js
+++ b/js/mui.class.scroll.js
@@ -31,6 +31,8 @@
 		init: function(element, options) {
 			this.wrapper = this.element = element;
 			this.scroller = this.wrapper.children[0];
+			//chrome 58版本后阻止原生touch的默认行为推荐使用方法
+			this.scroller && (this.scroller.style.touchAction ='none');
 			this.scrollerStyle = this.scroller && this.scroller.style;
 			this.stopped = false;
 

--- a/js/mui.class.scroll.slider.js
+++ b/js/mui.class.scroll.slider.js
@@ -189,8 +189,8 @@
 					if (!slider) {
 						return;
 					}
-					//仅slider显示状态进行自动轮播
-					if (!!(slider.offsetWidth || slider.offsetHeight)) {
+					//仅slider显示状态、并且在可视区内部时进行自动轮播
+					if (!!(slider.offsetWidth || slider.offsetHeight) && $.isInViewableArea(slider)) {
 						self.nextItem(true);
 						//下一个
 					}

--- a/js/mui.js
+++ b/js/mui.js
@@ -426,6 +426,15 @@ var mui = (function(document, undefined) {
 	$.each(['Boolean', 'Number', 'String', 'Function', 'Array', 'Date', 'RegExp', 'Object', 'Error'], function(i, name) {
 		class2type["[object " + name + "]"] = name.toLowerCase();
 	});
+	$.isInViewableArea = function(el) {
+		var rect = el.getBoundingClientRect();
+		return (
+			rect.top <= (window.innerHeight || document.documentElement.clientHeight) 
+			&&rect.bottom >0
+			&&rect.right >0
+			&&rect.left<= (window.innerWidth || document.documentElement.clientWidth)
+		);
+	};
 	if (window.JSON) {
 		$.parseJSON = JSON.parse;
 	}


### PR DESCRIPTION
判断元素是否在可视区域的方法可公共出来，可优化移动端性能；
从chrome58起，阻止浏览器touch默认行为的老方法已过期，继续使用控制台会产生警报：
`[Intervention] Unable to preventDefault inside passive event listener due to target being treated as passive. See https://www.chromestatus.com/features/5093566007214080`
![image](https://user-images.githubusercontent.com/10484248/31704993-4e7a38a4-b3a9-11e7-90ae-d2f793b73092.png)
谷歌推荐使用css3的`touch-action:none`来解决，
参考链接：https://developers.google.com/web/updates/2017/01/scrolling-intervention
https://w3c.github.io/pointerevents/#the-touch-action-css-property
仔细测试了一翻，我直接加touch-action来解决还是过于粗暴，mui中一些手势可能会有问题