### PR TITLE
mui.class.scroll.js 解决某些情况下wrapper发生原生滚动导致组件无法向上回滚的问题

### DIFF
--- a/js/mui.class.scroll.js
+++ b/js/mui.class.scroll.js
@@ -700,7 +700,8 @@
 		},
 		resetPosition: function(time) {
 			var x = this.x,
-				y = this.y;
+				y = this.y,
+				dy = this.wrapper.scrollTop;
 
 			time = time || 0;
 			if (!this.hasHorizontalScroll || this.x > 0) {
@@ -715,6 +716,10 @@
 				y = this.maxScrollY;
 			}
 
+			if(dy > 0){
+				this.wrapper.scrollTop = 0;
+				y -= dy;
+			}
 			if (x == this.x && y == this.y) {
 				return false;
 			}


### PR DESCRIPTION
问题复现：在有自动变高的textarea组件的滚动页面中一直回车，将导致Scroll组件中的wrapper发生scroll，这时向下拖动页面将不能滚动到初始位置