### PR TITLE
修复某些情况下无法点击datepicker的确定/取消按钮

### DIFF
--- a/plugin/picker/js/mui.dtpicker.js
+++ b/plugin/picker/js/mui.dtpicker.js
@@ -127,7 +127,9 @@
 			self._create(options);
 			//防止滚动穿透
 			self.ui.picker.addEventListener($.EVENT_START, function(event) {
-				event.preventDefault();
+				if(event.srcElement.getAttribute('class').indexOf('mui-btn') == -1){
+					event.preventDefault();
+				}
 			}, false);
 			self.ui.picker.addEventListener($.EVENT_MOVE, function(event) {
 				event.preventDefault();


### PR DESCRIPTION
临时性修复在微信开发者工具/某些Chrome内核浏览器下无法点击datepicker的确定/取消按钮